### PR TITLE
Make download an option

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -6,6 +6,7 @@ define wp::site (
 	$admin_user     = 'admin',
 	$admin_email    = 'admin@example.com',
 	$admin_password = 'password',
+	$download		= false,
 	$network        = false,
 	$subdomains     = false
 ) {
@@ -21,10 +22,18 @@ define wp::site (
 		$install = "install --url='$url'"
 	}
 
+	if ( $download == true ) {
+		exec {"wp download $location":
+			command => "/usr/bin/wp core download",
+			cwd => $location,
+			require => [ Class['wp::cli'] ],
+			unless => '/usr/bin/wp core is-installed'
+		}
+	}
 	exec {"wp install $location":
 		command => "/usr/bin/wp core $install --title='$sitename' --admin_email='$admin_email' --admin_name='$admin_user' --admin_password='$admin_password'",
 		cwd => $location,
-		require => [ Class['wp::cli'] ],
+		require => [ Class['wp::cli'], Exec["wp download $location"] ],
 		unless => '/usr/bin/wp core is-installed'
 	}
 


### PR DESCRIPTION
By adding a parameter that defaults to `false`, existing installs should remain unaffected.
