### PR TITLE
user parameter was missing from the exec within wp::plugin.

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -12,7 +12,7 @@ define wp::plugin (
 
 			exec { "wp install plugin $title":
 				cwd     => $location,
-        user    => $::wp::user,				
+				user    => $::wp::user,				
 				command => "/usr/bin/wp plugin install $slug",
 				unless  => "/usr/bin/wp plugin is-installed $slug",
 				before  => Wp::Command["$location plugin $slug $ensure"],

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -12,6 +12,7 @@ define wp::plugin (
 
 			exec { "wp install plugin $title":
 				cwd     => $location,
+        user    => $::wp::user,				
 				command => "/usr/bin/wp plugin install $slug",
 				unless  => "/usr/bin/wp plugin is-installed $slug",
 				before  => Wp::Command["$location plugin $slug $ensure"],


### PR DESCRIPTION
Plugin installation was failing on puppet apply runs due to the warning issued to root users executing wp commands. Set to the same user as is used in wp::command.