### PR TITLE
Convert to network on provision

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -13,12 +13,27 @@ define wp::site (
 
 	if ( $network == true ) and ( $subdomains == true ) {
 		$install = "multisite-install --subdomains --url='$url'"
+		$convert = "multisite-convert --subdomains --url='$url'"
 	}
 	elsif ( $network == true ) {
 		$install = "multisite-install --url='$url'"
+		$convert = "multisite-convert --url='$url'"
 	}
 	else {
 		$install = "install --url='$url'"
+	}
+
+	if ( $network ) {
+		exec {"wp multisite-convert $location":
+			command => "/usr/bin/wp core $convert",
+			cwd => $location,
+			logoutput => true,
+			user => $::wp::user,
+			require => [ Class['wp::cli'] ],
+			before => [ Exec[ "wp install $location" ] ],
+			onlyif => '/usr/bin/wp core is-installed',
+			unless => '/usr/bin/wp core is-installed --network',
+		}
 	}
 
 	exec {"wp install $location":


### PR DESCRIPTION
When moving from `network => false` to `network => true`, let's convert to multisite.

Currently blocked on https://github.com/wp-cli/wp-cli/issues/3641