### PR TITLE
Allow configuring the PHP package

### DIFF
--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -5,13 +5,6 @@ class wp::cli (
 ) {
 	include wp
 
-	$phpprefix = $::operatingsystem ? {
-		'RedHat'		=> 'php',
-		'CentOS'		=> 'php',
-		/^(Debian|Ubuntu)$/	=> 'php5',
-		default			=> 'php',
-	} 
-
 	if 'installed' == $ensure or 'present' == $ensure {
 		# Create the install path
 		file { [ "$install_path", "$install_path/bin" ]:
@@ -48,8 +41,8 @@ class wp::cli (
 		}
 	}
 
-	if ! defined(Package["$phpprefix-cli"]) {
-		package { "$phpprefix-cli":
+	if ! defined( Package[ $::wp::php_package ] ) {
+		package { $::wp::php_package:
 			ensure => installed,
 		}
 	}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 class wp (
 	$user = $::wp::params::user,
+	$php_package = $::wp::params::php_package,
 ) inherits wp::params {
 	# ...
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,7 +2,7 @@ class wp::params {
 	$user = 'www-data'
 
 	$php_package = $::operatingsystem ? {
-		/^(Debian|Ubuntu)$/	=> 'php5-cli',
-		default			    => 'php-cli',
+		/^(Debian|Ubuntu)$/ => 'php5-cli',
+		default             => 'php-cli',
 	}
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,3 +1,8 @@
 class wp::params {
 	$user = 'www-data'
+
+	$php_package = $::operatingsystem ? {
+		/^(Debian|Ubuntu)$/	=> 'php5-cli',
+		default			    => 'php-cli',
+	}
 }


### PR DESCRIPTION
See #25, #27. With recent updates to PHP packaging in Ubuntu, the package names have changed. Allowing this to be configured hits the sweet spot.